### PR TITLE
SONAR-18: Exclude AMD modules from function parameter count constraints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,3 @@ sudo: false
 language: java
 jdk:
   - oraclejdk8
-notifications:
-  email: false

--- a/src/main/java/com/wikia/sonarjs/rules/JavaScriptRuleDefinitions.java
+++ b/src/main/java/com/wikia/sonarjs/rules/JavaScriptRuleDefinitions.java
@@ -1,5 +1,6 @@
 package com.wikia.sonarjs.rules;
 
+import com.wikia.sonarjs.rules.checks.AmdExcludedFunctionParameterCountCheck;
 import com.wikia.sonarjs.rules.checks.es6.*;
 import com.wikia.sonarjs.rules.xml.RulesXmlInputStreamFactory;
 
@@ -24,7 +25,7 @@ public class JavaScriptRuleDefinitions extends CustomJavaScriptRulesDefinition {
 	}
 
 	@VisibleForTesting
-	public JavaScriptRuleDefinitions(RulesXmlInputStreamFactory factory) {
+	JavaScriptRuleDefinitions(RulesXmlInputStreamFactory factory) {
 		xmlInputStreamFactory = factory;
 	}
 
@@ -64,6 +65,7 @@ public class JavaScriptRuleDefinitions extends CustomJavaScriptRulesDefinition {
 	@Override
 	public Class[] checkClasses() {
 		return new Class[] {
+			AmdExcludedFunctionParameterCountCheck.class,
 			ArrowFunctionCheck.class,
 			ClassCheck.class,
 			ConstLetUseCheck.class,

--- a/src/main/java/com/wikia/sonarjs/rules/checks/AmdExcludedFunctionParameterCountCheck.java
+++ b/src/main/java/com/wikia/sonarjs/rules/checks/AmdExcludedFunctionParameterCountCheck.java
@@ -1,0 +1,85 @@
+package com.wikia.sonarjs.rules.checks;
+
+import com.google.common.collect.ImmutableSet;
+import org.sonar.check.Rule;
+import org.sonar.check.RuleProperty;
+import org.sonar.plugins.javascript.api.tree.Tree;
+import org.sonar.plugins.javascript.api.tree.Tree.Kind;
+import org.sonar.plugins.javascript.api.tree.declaration.FunctionDeclarationTree;
+import org.sonar.plugins.javascript.api.tree.declaration.MethodDeclarationTree;
+import org.sonar.plugins.javascript.api.tree.declaration.ParameterListTree;
+import org.sonar.plugins.javascript.api.tree.expression.CallExpressionTree;
+import org.sonar.plugins.javascript.api.tree.expression.FunctionExpressionTree;
+import org.sonar.plugins.javascript.api.visitors.DoubleDispatchVisitorCheck;
+
+import javax.annotation.Nonnull;
+import java.util.Set;
+
+@Rule(key = "AmdExcludedFunctionParameterLimit")
+public class AmdExcludedFunctionParameterCountCheck extends DoubleDispatchVisitorCheck {
+	final private static String MESSAGE = "Function has %d parameters which is greater than %d authorized.";
+
+	/**
+	 * AMD functions where the maximum parameter limit is ignored - it seems this cannot be configured via @RuleProperty
+	 */
+	final private static Set<String> amdFunctions = ImmutableSet.of("require", "define");
+
+	final private static int DEFAULT_MAXIMUM_ALLOWED_PARAMETER_COUNT = 4;
+
+	@RuleProperty(key = "maximumFunctionParameters")
+	private int maximumAllowedParameterCount = DEFAULT_MAXIMUM_ALLOWED_PARAMETER_COUNT;
+
+	private boolean isCurrentFunctionExpressionWhitelisted = false;
+
+	@Override
+	public void visitFunctionDeclaration(@Nonnull FunctionDeclarationTree tree) {
+		checkParameterCount(tree.parameterClause());
+		super.visitFunctionDeclaration(tree);
+	}
+
+	@Override
+	public void visitMethodDeclaration(@Nonnull MethodDeclarationTree tree) {
+		checkParameterCount(tree.parameterClause());
+		super.visitMethodDeclaration(tree);
+	}
+
+	@Override
+	public void visitCallExpression(@Nonnull CallExpressionTree tree) {
+		Tree callee = tree.callee();
+
+		if (callee.is(Kind.IDENTIFIER_REFERENCE) && amdFunctions.contains(callee.toString())) {
+			isCurrentFunctionExpressionWhitelisted = true;
+			super.visitCallExpression(tree);
+			isCurrentFunctionExpressionWhitelisted = false;
+
+			return;
+		}
+
+		super.visitCallExpression(tree);
+	}
+
+	@Override
+	public void visitFunctionExpression(@Nonnull FunctionExpressionTree tree) {
+		if (!isCurrentFunctionExpressionWhitelisted) {
+			checkParameterCount(tree.parameterClause());
+		}
+
+		super.visitFunctionExpression(tree);
+	}
+
+	private void checkParameterCount(@Nonnull ParameterListTree parameterListTree) {
+		Integer paramsCount = parameterListTree.parameters().size();
+
+		if (paramsCount > maximumAllowedParameterCount) {
+			addIssue(parameterListTree, String.format(MESSAGE, paramsCount, maximumAllowedParameterCount));
+		}
+	}
+
+	/**
+	 * Used by Sonar to optionally set a user-defined threshold for maximum allowed parameters
+	 * @param threshold The maximum allowed parameter count
+	 */
+	public void setMaximumAllowedParameterCount(int threshold) {
+		this.maximumAllowedParameterCount = threshold;
+	}
+}

--- a/src/main/resources/com/wikia/sonarjs/rules/rules.xml
+++ b/src/main/resources/com/wikia/sonarjs/rules/rules.xml
@@ -1,7 +1,52 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <rules xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="rules.xsd">
-	<rule>
-		<key>ArrowFunctions</key>
+	<rule key="AmdExcludedFunctionParameterLimit">
+		<name>Functions that are not AMD module definitions should not have too many parameters</name>
+		<description><![CDATA[
+			<p>A long parameter list can indicate that a new structure should be created to wrap the numerous parameters or that the function is doing too many things.</p>
+			<p>Functions that are AMD modules are exempted from this rule as they use parameters to facilitate dependency injection.</p>
+			<h2>Noncompliant Code Example</h2>
+			<p>With a maximum number of 4 parameters:</p>
+			<pre>
+				function doSomething(param1, param2, param3, param4, param5) {
+				...
+				}
+
+				// AMD module definition
+				define(
+					'wikia.awesomeModule',
+					['jquery', 'mw', 'wikia.window', 'wikia.tracker', 'wikia.geo'],
+					function ($, mw, context, tracker, geo) {
+					...
+					}
+				);
+
+				// AMD require
+				require(
+					['jquery', 'mw', 'wikia.window', 'wikia.tracker', 'wikia.geo'],
+					function ($, mw, context, tracker, geo) {}
+				);
+			</pre>
+			<h2>Compliant Solution</h2>
+			<pre>
+				function doSomething(param1, param2, param3, param4) {
+				...
+				}
+			</pre>
+		]]></description>
+
+		<type>CODE_SMELL</type>
+		<severity>MAJOR</severity>
+		<tag>brain-overload</tag>
+		<remediationFunction>CONSTANT_ISSUE</remediationFunction>
+		<remediationFunctionBaseEffort>20min</remediationFunctionBaseEffort>
+
+		<param key="maximumFunctionParameters">
+			<description>The maximum authorized number of parameters</description>
+			<defaultValue>4</defaultValue>
+		</param>
+	</rule>
+	<rule key="ArrowFunctions">
 		<name>Arrow functions cannot be used in ES5</name>
 		<description><![CDATA[
 			<p>
@@ -27,8 +72,7 @@
 		<remediationFunction>CONSTANT_ISSUE</remediationFunction>
 		<remediationFunctionBaseEffort>10min</remediationFunctionBaseEffort>
 	</rule>
-	<rule>
-		<key>Classes</key>
+	<rule key="Classes">
 		<name>Classes cannot be used in ES5</name>
 		<description><![CDATA[
 			<p>
@@ -61,8 +105,7 @@
 		<remediationFunction>CONSTANT_ISSUE</remediationFunction>
 		<remediationFunctionBaseEffort>10min</remediationFunctionBaseEffort>
 	</rule>
-	<rule>
-		<key>ConstLet</key>
+	<rule key="ConstLet">
 		<name>Variables cannot be declared with const or let in ES5</name>
 		<description><![CDATA[
 			<p>
@@ -94,8 +137,7 @@
 		<remediationFunction>CONSTANT_ISSUE</remediationFunction>
 		<remediationFunctionBaseEffort>10min</remediationFunctionBaseEffort>
 	</rule>
-	<rule>
-		<key>Generators</key>
+	<rule key="Generators">
 		<name>Generators cannot be used in ES5</name>
 		<description><![CDATA[
 			<p>
@@ -111,7 +153,7 @@
 		<remediationFunction>CONSTANT_ISSUE</remediationFunction>
 		<remediationFunctionBaseEffort>1h</remediationFunctionBaseEffort>
 	</rule>
-	<rule>
+	<rule key="Iterators">
 		<key>Iterators</key>
 		<name>Iterators cannot be used in ES5"</name>
 		<description><![CDATA[
@@ -145,8 +187,7 @@
 		<remediationFunction>CONSTANT_ISSUE</remediationFunction>
 		<remediationFunctionBaseEffort>10min</remediationFunctionBaseEffort>
 	</rule>
-	<rule>
-		<key>Literals</key>
+	<rule key="Literals">
 		<name>Binary and octal numeric literals cannot be used in ES5</name>
 		<description><![CDATA[
 			<p>
@@ -174,8 +215,7 @@
 		<remediationFunction>CONSTANT_ISSUE</remediationFunction>
 		<remediationFunctionBaseEffort>10min</remediationFunctionBaseEffort>
 	</rule>
-	<rule>
-		<key>PropertyShorthands</key>
+	<rule key="PropertyShorthands">
 		<name>Shorthand object properties cannot be used in ES5</name>
 		<description><![CDATA[
 			<p>
@@ -206,8 +246,7 @@
 		<remediationFunction>CONSTANT_ISSUE</remediationFunction>
 		<remediationFunctionBaseEffort>10min</remediationFunctionBaseEffort>
 	</rule>
-	<rule>
-		<key>StringInterpolation</key>
+	<rule key="StringInterpolation">
 		<name>Template strings cannot be used in ES5</name>
 		<description><![CDATA[
 			<p>

--- a/src/main/resources/com/wikia/sonarjs/rules/rules.xsd
+++ b/src/main/resources/com/wikia/sonarjs/rules/rules.xsd
@@ -6,7 +6,7 @@
 				<xs:element name="rule" maxOccurs="unbounded">
 					<xs:complexType>
 						<xs:sequence>
-							<xs:element name="key" type="xs:string"/>
+							<xs:element name="key" type="xs:string" minOccurs="0"/>
 							<xs:element name="name" type="xs:string"/>
 							<xs:element name="description" type="xs:string"/>
 							<xs:element name="descriptionFormat" minOccurs="0">
@@ -56,15 +56,6 @@
 								</xs:simpleType>
 							</xs:element>
 							<xs:element name="tag" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
-							<xs:element name="param" minOccurs="0" maxOccurs="unbounded">
-								<xs:complexType>
-									<xs:sequence>
-										<xs:element name="key" type="xs:string"/>
-										<xs:element name="description" type="xs:string" minOccurs="0"/>
-										<xs:element name="defaultValue" type="xs:string" minOccurs="0"/>
-									</xs:sequence>
-								</xs:complexType>
-							</xs:element>
 							<xs:element name="remediationFunction">
 								<xs:simpleType>
 									<xs:restriction base="xs:string">
@@ -79,7 +70,17 @@
 								<xs:element name="remediationFunctionBaseEffort" type="xs:string"/>
 								<xs:element name="remediationFunctionGapMultiplier" type="xs:string"/>
 							</xs:choice>
+							<xs:element name="param" minOccurs="0" maxOccurs="unbounded">
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="description" type="xs:string"/>
+										<xs:element name="defaultValue" type="xs:string"/>
+									</xs:sequence>
+									<xs:attribute name="key" type="xs:string" use="required" />
+								</xs:complexType>
+							</xs:element>
 						</xs:sequence>
+						<xs:attribute name="key" type="xs:string" use="required" />
 					</xs:complexType>
 				</xs:element>
 			</xs:sequence>

--- a/src/test/java/com/wikia/sonarjs/rules/PluginTest.java
+++ b/src/test/java/com/wikia/sonarjs/rules/PluginTest.java
@@ -17,15 +17,15 @@ public class PluginTest {
 	@SuppressWarnings("unchecked")
 	public void pluginIsRegistered() {
 		JavaScriptRulesPlugin javaScriptRulesPlugin = new JavaScriptRulesPlugin();
-		Context context = getMockContext();
+		Context context = new Context(getMockSonarRuntime());
 
 		javaScriptRulesPlugin.define(context);
 
 		assertThat((List<Class>) context.getExtensions(), hasItem(JavaScriptRuleDefinitions.class));
 	}
 
-	private Context getMockContext() {
-		return new Context(new SonarRuntime() {
+	private SonarRuntime getMockSonarRuntime() {
+		return new SonarRuntime() {
 			@Override
 			public Version getApiVersion() {
 				return null;
@@ -40,6 +40,6 @@ public class PluginTest {
 			public SonarQubeSide getSonarQubeSide() {
 				return null;
 			}
-		});
+		};
 	}
 }

--- a/src/test/java/com/wikia/sonarjs/rules/checks/AmdExcludedFunctionParameterCountCheckTest.java
+++ b/src/test/java/com/wikia/sonarjs/rules/checks/AmdExcludedFunctionParameterCountCheckTest.java
@@ -1,0 +1,23 @@
+package com.wikia.sonarjs.rules.checks;
+
+import org.junit.Test;
+import org.sonar.javascript.checks.verifier.JavaScriptCheckVerifier;
+
+import java.io.File;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.junit.Assert.assertThat;
+
+public class AmdExcludedFunctionParameterCountCheckTest extends RuleTest {
+	@Test
+	public void ruleIsLoaded() {
+		super.ruleIsLoaded();
+
+		assertThat(actualRuleList, hasItem(AmdExcludedFunctionParameterCountCheck.class));
+	}
+
+	@Test
+	public void nonWhiteListedFunctionsWithTooManyParametersAreNonCompliant() {
+		JavaScriptCheckVerifier.verify(new AmdExcludedFunctionParameterCountCheck(), new File("src/test/resources/AmdExcludedFunctionParameterCountCheck.js"));
+	}
+}

--- a/src/test/resources/AmdExcludedFunctionParameterCountCheck.js
+++ b/src/test/resources/AmdExcludedFunctionParameterCountCheck.js
@@ -1,0 +1,22 @@
+require(
+	['jquery', 'mw', 'wikia.window', 'wikia.tracker', 'wikia.geo'],
+	function ($, mw, context, tracker, geo) {}
+);
+
+define(
+	'wikia.awesomeModule',
+	['jquery', 'mw', 'wikia.window', 'wikia.tracker', 'wikia.geo'],
+	function ($, mw, context, tracker, geo) {}
+);
+
+function smallCompliantFunction(a, b, c, d) {}
+
+function bigEvilFunction(a, b, c, d, e) {} // Noncompliant
+
+var o = {
+	smallCompliantMethod: function (a, b, c, d) {},
+	bigEvilMethod: function (a, b, c, d, e) {} // Noncompliant
+};
+
+someCompliantAsyncThing.doStuffWithCallback(function (a, b, c, d) {});
+someEvilAsyncThing.doStuffWithCallback(function (a, b, c, d, e) {}); // Noncompliant


### PR DESCRIPTION
Make Sonar respect our [coding conventions](https://github.com/Wikia/guidelines/blob/master/JavaScript/CodingConventions.md#maximum-parameters) by excluding AMD modules from the maximum function parameter limit of 4 while continuing to apply this restriction elsewhere.

https://wikia-inc.atlassian.net/browse/SONAR-18