### PR TITLE
SONAR-22: Mark usage of $.proxy polyfill as code smell

### DIFF
--- a/src/main/java/com/wikia/sonarjs/rules/JavaScriptRuleDefinitions.java
+++ b/src/main/java/com/wikia/sonarjs/rules/JavaScriptRuleDefinitions.java
@@ -1,6 +1,6 @@
 package com.wikia.sonarjs.rules;
 
-import com.wikia.sonarjs.rules.checks.AmdExcludedFunctionParameterCountCheck;
+import com.wikia.sonarjs.rules.checks.*;
 import com.wikia.sonarjs.rules.checks.es6.*;
 import com.wikia.sonarjs.rules.xml.RulesXmlInputStreamFactory;
 
@@ -71,6 +71,7 @@ public class JavaScriptRuleDefinitions extends CustomJavaScriptRulesDefinition {
 			ConstLetUseCheck.class,
 			GeneratorCheck.class,
 			IteratorCheck.class,
+			JqueryProxyUsageCheck.class,
 			LiteralsCheck.class,
 			PropertyShorthandCheck.class,
 			StringInterpolationCheck.class

--- a/src/main/java/com/wikia/sonarjs/rules/checks/JqueryProxyUsageCheck.java
+++ b/src/main/java/com/wikia/sonarjs/rules/checks/JqueryProxyUsageCheck.java
@@ -1,0 +1,35 @@
+package com.wikia.sonarjs.rules.checks;
+
+import org.sonar.check.Rule;
+import org.sonar.plugins.javascript.api.tree.Tree.Kind;
+import org.sonar.plugins.javascript.api.tree.expression.ExpressionTree;
+import org.sonar.plugins.javascript.api.tree.expression.MemberExpressionTree;
+import org.sonar.plugins.javascript.api.visitors.DoubleDispatchVisitorCheck;
+
+import javax.annotation.Nonnull;
+
+@Rule(key = "JqueryProxyUsage")
+public class JqueryProxyUsageCheck extends DoubleDispatchVisitorCheck {
+	final private static String MESSAGE = "Convert this use of $.proxy polyfill to Function.prototype.bind.";
+
+	final private static String $ = "$";
+	final private static String PROXY = "proxy";
+
+	@Override
+	public void visitMemberExpression(@Nonnull MemberExpressionTree tree) {
+		ExpressionTree object = tree.object();
+		ExpressionTree property = tree.property();
+
+		if (object.is(Kind.IDENTIFIER_REFERENCE) && property.is(Kind.PROPERTY_IDENTIFIER)) {
+			checkForJqueryProxy(object, property);
+		}
+
+		super.visitMemberExpression(tree);
+	}
+
+	private void checkForJqueryProxy(ExpressionTree object, ExpressionTree property) {
+		if (object.toString().equals($) && property.toString().equals(PROXY)) {
+			addIssue(property, MESSAGE);
+		}
+	}
+}

--- a/src/main/resources/com/wikia/sonarjs/rules/rules.xml
+++ b/src/main/resources/com/wikia/sonarjs/rules/rules.xml
@@ -187,6 +187,38 @@
 		<remediationFunction>CONSTANT_ISSUE</remediationFunction>
 		<remediationFunctionBaseEffort>10min</remediationFunctionBaseEffort>
 	</rule>
+	<rule key="JqueryProxyUsage">
+		<name>$.proxy polyfill should not be used</name>
+		<description><![CDATA[
+			<p>
+				<a href="https://api.jquery.com/jQuery.proxy/"><code>$.proxy</code></a> is a legacy polyfill for the native
+				<a href="https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_objects/Function/bind"><code>Function.prototype.bind</code></a> method.
+
+				Our supported browsers all support <code>Function.prototype.bind</code>, making the legacy polyfill redundant.
+			</p>
+			<h2>Noncompliant Code Example</h2>
+			<pre>
+			$.proxy(this.someMethod, this);
+			</pre>
+			<h2>Compliant Solution</h2>
+			<pre>
+			this.someMethod.bind(this);
+			</pre>
+			<h2>See</h2>
+			<ul>
+				<li>
+					<a href="https://github.com/Wikia/guidelines/blob/master/JavaScript/CodingConventions.md#setting-context-using-bind">Wikia JavaScript ES5 Coding Conventions</a>&nbsp;-&nbsp;Setting Context Using .bind()
+				</li>
+			</ul>
+		]]></description>
+
+		<type>CODE_SMELL</type>
+		<severity>MINOR</severity>
+		<tag>clumsy</tag>
+		<tag>convention</tag>
+		<remediationFunction>CONSTANT_ISSUE</remediationFunction>
+		<remediationFunctionBaseEffort>10min</remediationFunctionBaseEffort>
+	</rule>
 	<rule key="Literals">
 		<name>Binary and octal numeric literals cannot be used in ES5</name>
 		<description><![CDATA[

--- a/src/test/java/com/wikia/sonarjs/rules/checks/JqueryProxyUsageCheckTest.java
+++ b/src/test/java/com/wikia/sonarjs/rules/checks/JqueryProxyUsageCheckTest.java
@@ -1,0 +1,23 @@
+package com.wikia.sonarjs.rules.checks;
+
+import org.junit.Test;
+import org.sonar.javascript.checks.verifier.JavaScriptCheckVerifier;
+
+import java.io.File;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.junit.Assert.assertThat;
+
+public class JqueryProxyUsageCheckTest extends RuleTest {
+	@Test
+	public void ruleIsLoaded() {
+		super.ruleIsLoaded();
+
+		assertThat(actualRuleList, hasItem(JqueryProxyUsageCheck.class));
+	}
+
+	@Test
+	public void jQueryProxyUsageIsNoncompliant() {
+		JavaScriptCheckVerifier.verify(new JqueryProxyUsageCheck(), new File("src/test/resources/JqueryProxyUsageCheck.js"));
+	}
+}

--- a/src/test/resources/JqueryProxyUsageCheck.js
+++ b/src/test/resources/JqueryProxyUsageCheck.js
@@ -1,0 +1,6 @@
+$.proxy(function() {}, this); // Noncompliant
+$.proxy(this.someMethod, this); // Noncompliant
+
+$.each(someArray, function (item, i) {});
+
+$('body').removeClass('foo');


### PR DESCRIPTION
Mark usage of `$.proxy` polyfill as code smell and indicate that `Function.prototype.bind` should be preferred, as per [our conventions](https://github.com/Wikia/guidelines/blob/master/JavaScript/CodingConventions.md#setting-context-using-bind).